### PR TITLE
Fix Graylog (opensearch/elasticsearch) date field parsing issues

### DIFF
--- a/src/Gelf.Extensions.Logging/Gelf.Extensions.Logging.csproj
+++ b/src/Gelf.Extensions.Logging/Gelf.Extensions.Logging.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>0.2.4</VersionPrefix>
+    <VersionPrefix>0.2.5</VersionPrefix>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <Title>Alexr03.Gelf.Extensions.Logging</Title>
     <Authors>Matt Cole, Alex Redding</Authors>
-    <Description>GELF provider for Microsoft.Extensions.Logging with TCP TLS Certificate Authentication support</Description>
+    <Description>GELF provider for Microsoft.Extensions. Logging with TCP TLS Certificate Authentication support</Description>
     <RepositoryUrl>https://github.com/mattwcole/gelf-extensions-logging</RepositoryUrl>
     <PackageProjectUrl>https://github.com/alexr03/gelf-extensions-logging</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
@@ -16,7 +16,7 @@
     <PackageTags>gelf graylog microsoft logging extensions</PackageTags>
     <Copyright>2017 Matt Cole</Copyright>
     <PackageId>Alexr03.Gelf.Extensions.Logging</PackageId>
-    <Version>0.2.4</Version>
+    <Version>0.2.5</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/Gelf.Extensions.Logging/GelfMessageExtensions.cs
+++ b/src/Gelf.Extensions.Logging/GelfMessageExtensions.cs
@@ -73,10 +73,10 @@ public static class GelfMessageExtensions
                 jsonWriter.WriteNumber(key, value);
                 break;
             case DateTime value:
-                jsonWriter.WriteNumber(key, Utilities.GetTimestamp((DateTimeOffset)value));
+                jsonWriter.WriteNumber(key, Utilities.GetTimestampMilliseconds((DateTimeOffset)value));
                 break;
             case DateTimeOffset value:
-                jsonWriter.WriteNumber(key, Utilities.GetTimestamp(value));
+                jsonWriter.WriteNumber(key, Utilities.GetTimestampMilliseconds(value));
                 break;
             default:
                 jsonWriter.WriteString(key, field.Value.ToString());

--- a/src/Gelf.Extensions.Logging/Utilities.cs
+++ b/src/Gelf.Extensions.Logging/Utilities.cs
@@ -11,4 +11,10 @@ public static class Utilities
         var totalSeconds = totalMilliseconds / 1000d;
         return Math.Round(totalSeconds, 3);
     }
+
+    public static long GetTimestampMilliseconds(DateTimeOffset? dateTime = null)
+    {
+        dateTime ??= DateTimeOffset.UtcNow;
+        return dateTime.Value.ToUnixTimeMilliseconds();
+    }
 }


### PR DESCRIPTION
Additional date fields have to be epoch milliseconds, while message timestamp is epoch seconds double with optional decimal milliseconds